### PR TITLE
Stubbed out view with React components and stylings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-ReactDOM.render(<h1>IVI</h1>, document.getElementById('app'))
+import Interpreter from './view';
+
+ReactDOM.render(<Interpreter />, document.getElementById('app'))

--- a/src/view/console/index.js
+++ b/src/view/console/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Console = () => (
+  <div className="component__console">
+    <h2>Console</h2>    
+  </div>
+)
+
+export default Console

--- a/src/view/editor/index.js
+++ b/src/view/editor/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Editor = () => (
+  <div className="component__editor">
+    <h2>Editor</h2>    
+  </div>
+)
+
+export default Editor

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import Console from './console'
+import Editor from './editor'
+import Navbar from './navbar'
+import Visualizer from './visualizer'
+
+import './styles/index.scss'
+
+export default class Interpreter extends React.Component {
+  render() {
+    return (
+      <div className="component__interpreter">
+        <Console />
+        <Editor />
+        <Navbar />
+        <Visualizer />
+      </div>
+    )
+  }
+}

--- a/src/view/navbar/index.js
+++ b/src/view/navbar/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Navbar = () => (
+  <div className="component__navbar">
+    <h2>Navbar</h2>    
+  </div>
+)
+
+export default Navbar

--- a/src/view/styles/index.scss
+++ b/src/view/styles/index.scss
@@ -1,0 +1,11 @@
+html,
+body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+
+#app,
+[data-reactroot] {
+  height: 100% !important;
+}

--- a/src/view/visualizer/index.js
+++ b/src/view/visualizer/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Visualizer = () => (
+  <div className="component__visualizer">
+    <h2>Visualizer</h2>    
+  </div>
+)
+
+export default Visualizer

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
         test: /\.(css|scss)$/,
         loader: [
           'style-loader',
-          { loader: 'css-loader', options: { modules: true } },
+          { loader: 'css-loader', options: { modules: false } },
           'sass-loader',
         ],
       },


### PR DESCRIPTION
This sets up the React app with multiple components. This implements the folder structure for `view`, which is detailed here: https://docs.google.com/document/d/1dkiRFgh1rcb5XaA626r5z0sdyv_lF0f2d8csnurAjnY/edit#heading=h.mo1plist9yxj

This PR also changes the `webpack.config.js` file to disable CSS modules, as they were obfuscating the CSS code. 