### PR TITLE
Added Console functionality for literal strings and fixed bug

### DIFF
--- a/src/interpreter/executor/interpret.js
+++ b/src/interpreter/executor/interpret.js
@@ -19,6 +19,7 @@ class LineRep {
         this.lineNumber = -1;
         this.dataArray = [];
         this.consoleOutput = "";
+        this.unsupported = false;
     }
 }
 
@@ -97,6 +98,7 @@ function interpretLine(lineNumber) {
 
         //Fresh buffer for each statement
         let buffer = "";
+        currentState = stateEnum.DEFAULT;
 
         // Iterate each character in the current user code line
         for (let j = 0; j < statement.length; j++) {
@@ -117,6 +119,7 @@ function interpretLine(lineNumber) {
 
             //Skip on cases not yet covered yet
             if (isNotCovered(buffer)) {
+                currentLineRep.unsupported = true;
                 buffer = "";
                 break;
             }
@@ -258,6 +261,12 @@ function isNotCovered(buffer) {
         isNotCovered = true;
     } else if (buffer.includes("()")) {
         isNotCovered = true;
+    } else if (buffer.includes("class")) {
+        isNotCovered = true;
+    } else if (buffer.includes("let")) {
+        isNotCovered = true;
+    } else if (buffer.includes("const")) {
+        isNotCovered = true;
     }
 
     return isNotCovered;
@@ -362,6 +371,9 @@ function masterRepToString(representation) {
         console.log("Line Number: " + rep.lineNumber);
         if (rep.lineNumber != "") {
             console.log("Console output: " + rep.consoleOutput);
+        }
+        if (rep.unsupported) {
+            console.log("Unsupported element at line: " + rep.lineNumber);
         }
 
         rep.dataArray.forEach(function(dataClass) {

--- a/src/interpreter/executor/interpret.js
+++ b/src/interpreter/executor/interpret.js
@@ -3,7 +3,8 @@
 const stateEnum = {
     DEFAULT : "default",
     ACCEPTING_VAR : "accepting variable",
-    ASSIGNING_VAR : "assigning variable"
+    ASSIGNING_VAR : "assigning variable",
+    ACCEPTING_CONSOLE : "accepting console"
 }
 
 class Variable {
@@ -182,12 +183,30 @@ function resolveState(buffer) {
 
         case stateEnum.ASSIGNING_VAR:
             //We may want to talk about type inference
+            buffer = specialAssignments(buffer);
             currentDataHold.value = buffer;
+            currentState = stateEnum.DEFAULT;
+            break;
+        
+        case stateEnum.ACCEPTING_CONSOLE:
             currentState = stateEnum.DEFAULT;
             break;
     }
 }
 
+
+// Handle special assignment cases that result in undefined variable
+function specialAssignments(buffer) {
+
+    //Catch case where variable is assigned to console log
+    if (buffer.includes("console.log(")) {
+        currentLineRep.consoleOutput = buffer.substring(buffer.lastIndexOf("console.log(" + 1, 
+                                                                            buffer.length - 2));
+        buffer = "";
+    }
+
+    return buffer;
+}
 //If we believe we did not catch var but think there is a variable check it
 function noKeywordVariable(buffer) {
 
@@ -233,8 +252,6 @@ function isNotCovered(buffer) {
 
     if (buffer.includes("function")) {
         isNotCovered = true;
-    } else if (buffer.includes("console")) {
-        isNotCovered = true;
     } else if (buffer.includes("{")) {
         isNotCovered = true;
     } else if (buffer.includes("}")) {
@@ -262,6 +279,22 @@ function evalState(buffer) {
 
         case stateEnum.ASSIGNING_VAR:
             break;
+
+        case stateEnum.ACCEPTING_CONSOLE:
+            buffer = acceptingConsole(buffer);
+            break;
+    }
+    return buffer;
+}
+
+// If we are taking in console input
+function acceptingConsole(buffer) {
+    
+    //There has to be a better way
+    if (buffer[buffer.length - 1] === ')') {
+        
+        currentLineRep.consoleOutput = buffer.substring(1, buffer.length - 2);
+        buffer = "";
     }
     return buffer;
 }
@@ -291,6 +324,10 @@ function findBufferState(buffer) {
             currentDataArray.push(currentDataHold);
             return "";
             break;
+        case "console.log(":
+            currentState = stateEnum.ACCEPTING_CONSOLE;           
+            return "";
+            break;
         default:
             currentState = stateEnum.DEFAULT;
             break;
@@ -307,10 +344,10 @@ function evaluate(inputCode) {
 
     if (!setup(inputCode)) {
         return false;
-    }    
-
+    }
+    
     //While we haven't evaluated all of our code
-    while (currentStep < userCode.length - 1) {
+    while (currentStep < userCode.length) {
         interpretLine(currentStep);
         currentStep += 1;
     }
@@ -323,6 +360,9 @@ function masterRepToString(representation) {
 
     representation.forEach(function(rep) {
         console.log("Line Number: " + rep.lineNumber);
+        if (rep.lineNumber != "") {
+            console.log("Console output: " + rep.consoleOutput);
+        }
 
         rep.dataArray.forEach(function(dataClass) {
             console.log(JSON.stringify(dataClass));
@@ -330,7 +370,10 @@ function masterRepToString(representation) {
     });
 }
 
-const code = `function helloWorld() {
+const code = `
+
+            var testing
+            function helloWorld() {
                 var a=2;
                 var b = 3
                 c = 4;
@@ -346,32 +389,10 @@ const code = `function helloWorld() {
                 */
                 console.log('hello');
                 var h = 2;
+                var x = console.log("test");
             }`;
 
-/* Expected output:
-
-    [  { lineNumber : 0,
-        dataArray  : [],
-        consoleOutput : ""
-    },
-
-    { lineNumber : 1,
-        dataArray  : [],
-        consoleOutput : ""
-    },
-    { lineNumber : 2,
-      dataArray : [ {
-                        name : a,
-                        value : 2
-      } ]
-      consoleOutput: ""
-    },
-      .
-      .
-      .
-   ]
-*/
-
+const codeB = `var x`;
 
 const ret = evaluate(code);
 if (!ret) {


### PR DESCRIPTION
#48 #58 #60 

# Description

Fixes issue #58 
Beginning of #48 
Now adding to our data representation console logs for literal string.
Logging variables will be worked on next.

Added flagging for unsupported code for console to look at.

# Change Log
`interpret.js` changed to accept console logs now.  Also fixed minor bug.
Adjusted output printer to show console output now.  Modified test code a bit.

# Manual Test Steps
Create an `index.html` which loads the script. Put testing code in a const and feed it into the execute function.  Call printer on result and confirm expected output.
