### PR TITLE
fixed bug where pressing step showed pause

### DIFF
--- a/src/view/index.js
+++ b/src/view/index.js
@@ -51,7 +51,7 @@ export default class Interpreter extends React.Component {
       }
 
       steps.reverse()
-      this.setState({ isRunning: true, interpreterSteps: steps, currentStep: 0, consoleOutput: [],})
+      this.setState({ isRunning: true, interpreterSteps: steps, isSteppingAutomatically: false, currentStep: 0, consoleOutput: [],})
       resolve()
     })
   }


### PR DESCRIPTION
\#78

# Description
Fixed the bug where pressing step after a completed run showed `pause` rather than `resume`.

# Change Log
-`view/index.js` : Step `isSteppingAutomatically` to false upon `evaluateCode`

# Manual Test Steps
Write some code, press `Run` and wait for it to complete. Then press `Step`. The `Run` button should now say `Resume`.

