### PR TITLE
added symbol table to visualizer

### DIFF
--- a/src/interpreter/executor/index.js
+++ b/src/interpreter/executor/index.js
@@ -1,4 +1,4 @@
-import { state, log, resetState } from './state';
+import { log, resetState, insertAtScope } from './state';
 import { evaluate } from './interpret';
 
 let output = null;
@@ -45,7 +45,7 @@ export function nextStep() {
     log.push(expression.output);
     break;
   case 'Variable':
-    state[expression.name] = expression.value;
+    insertAtScope(expression.scope, expression);
     break;
   default:
     break;
@@ -57,10 +57,6 @@ export function nextStep() {
 export function resetInterpreter() {
   output = null;
   resetState();
-}
-
-export function getState() {
-  return state;
 }
 
 export function getLog() {

--- a/src/interpreter/executor/state.js
+++ b/src/interpreter/executor/state.js
@@ -1,9 +1,10 @@
 export let state = {};
 export let log = [];
-export let symbolTable = {0 : {}};
+let symbolTable = {0 : {}};
 export let currScope = symbolTable[0];
 export let scope = [0];
 export let scopeLevel = 0;
+export let visualRep = [];
 
 export function resetState() {
   log = [];
@@ -11,6 +12,7 @@ export function resetState() {
   scopeLevel = 0;
   symbolTable = {0: {}};
   currScope = symbolTable[0];
+  visualRep = [];
 
   for (const key in state) {
     if (state.hasOwnProperty(key)) {
@@ -66,6 +68,26 @@ export function insertAtScope(scopeArr, variable) {
     currentScope = currentScope[scopeArr[i]];
   }
   currentScope[variable.name] = variable.value;
+  generateVisualRep(scopeArr);
+  console.log(visualRep);
+}
+
+export function generateVisualRep(scopeArr) {
+  let newRep = [];
+  let currentScope = symbolTable;
+  for (let i = 0; i < scopeArr.length; i++) {
+    newRep.push([]);
+  }
+
+  for (let i = 0; i < scopeArr.length; i++) {
+    currentScope = currentScope[scopeArr[i]];
+    for (let key in currentScope) {
+      if (!(currentScope[key] instanceof Object)) {
+        newRep[i].push([key, currentScope[key]]);
+      }
+    }
+  }
+  visualRep = newRep;
 }
 
 export function increaseScope() {

--- a/src/interpreter/executor/state.js
+++ b/src/interpreter/executor/state.js
@@ -1,6 +1,6 @@
 export let state = {};
 export let log = [];
-let symbolTable = {0 : {}};
+export let symbolTable = {0 : {}};
 export let currScope = symbolTable[0];
 export let scope = [0];
 export let scopeLevel = 0;
@@ -56,6 +56,17 @@ export function getClosestValue(varName) {
   return String(closest);
 }
 
+//Intake scope arr and input into symbol table
+export function insertAtScope(scopeArr, variable) {
+  let currentScope = symbolTable[0];
+  for (let i = 1; i < scopeArr.length; i++) {
+    if (currentScope[scopeArr[i]] === undefined) {
+      currentScope[scopeArr[i]] = {};
+    }
+    currentScope = currentScope[scopeArr[i]];
+  }
+  currentScope[variable.name] = variable.value;
+}
 
 export function increaseScope() {
   scopeLevel += 1;

--- a/src/interpreter/executor/state.js
+++ b/src/interpreter/executor/state.js
@@ -69,7 +69,6 @@ export function insertAtScope(scopeArr, variable) {
   }
   currentScope[variable.name] = variable.value;
   generateVisualRep(scopeArr);
-  console.log(visualRep);
 }
 
 export function generateVisualRep(scopeArr) {


### PR DESCRIPTION
#145 

# Description

Now that we have a symbol table and scope we need to change how our visualizer operates.
This allows the visualizer to use the table and enforce scope.

# Change Log
-`executor/index.js` : No longer insert into state, instead insert into symbol table
-`state.js`: Added method to insert a variable at a state given a scope array

# Manual Test Steps
You can console log the symbol table as the program progresses and see the change.

