### PR TITLE
fix variable resizing

### DIFF
--- a/src/view/visualizer/sketch/components/variable.js
+++ b/src/view/visualizer/sketch/components/variable.js
@@ -9,8 +9,8 @@ export class Variable {
 
   constructor(canvas) {
     this.canvas = canvas;
-    this.name = 'Variable';
-    this.value = 'Med length twits';
+    this.name = '';
+    this.value = null
     this.color = '';
     this.width = VAR_WIDTH;
     this.height = VAR_HEIGHT;
@@ -21,6 +21,30 @@ export class Variable {
   draw() {
     const p = this.canvas;
     p.push();
+
+    // conditional formatting based on length and hover
+    let printValue = this.value
+    if (!this.hovering) {
+      if (this.value.length > 6) {
+        let temp = '';
+
+        for (let i = 0; i < 3; i++) {
+          temp += this.value[i];
+        }
+
+        temp += '...'
+        printValue = temp
+      }
+
+    } else {
+
+      // Each variable extends a custom amount depending on string length
+      if (this.value.length > 6) {
+        this.width = VAR_WIDTH + (this.value.length - 6) * 8.5;
+      } else {
+        this.width = VAR_WIDTH;
+      }
+    }
 
     // Variable name
     p.noStroke();
@@ -55,32 +79,13 @@ export class Variable {
     p.noStroke();
     p.textStyle(p.BOLD);
 
-    if (!this.hovering && this.value.length > 4) {
-      this.originalPrint = false;
-      let temp = '';
-
-      for (let i = 0; i < 3; i++) {
-        temp += this.value[i];
-      }
-
-      temp += '...';
-      p.text(
-        temp,
-        this.x + 5,
-        this.y + FONT_SIZE - 1,
-        this.x + this.width,
-        this.y
-      );
-    } else {
-      p.text(
-        this.value,
-        this.x + 5,
-        this.y + FONT_SIZE - 1,
-        this.x + this.width,
-        this.y
-      );
-      this.hovering = false;
-    }
+    p.text(
+      printValue,
+      this.x + 5,
+      this.y + FONT_SIZE - 1,
+      this.x + this.width,
+      this.y
+    );
 
     p.pop();
   }

--- a/src/view/visualizer/sketch/sketch.js
+++ b/src/view/visualizer/sketch/sketch.js
@@ -24,7 +24,6 @@ export default p => {
   p.draw = () => {
 
     p.background('white');
-    console.log('draw');
 
     base = new Scope(p);
     base.width = p.width - 40;
@@ -33,6 +32,7 @@ export default p => {
     base.y = 20;
 
     let s = base;
+    VARIABLES = [];
     for (let i = 0; i < visualRep.length; i++) {
       if (i !== 0) {
         s.child = new Scope(p);
@@ -43,37 +43,23 @@ export default p => {
         variable.name = visualRep[i][j][0];
         variable.value = visualRep[i][j][1];
         s.variables.push(variable);
-        VARIABLES = [];
         VARIABLES.push(variable);
       }
     }
     base.draw();
-  };
 
-  if (VARIABLES.length > 0) {
+    if (VARIABLES.length > 0) {
+      VARIABLES.forEach(elem => {
+        if (p.mouseX > elem.x && p.mouseX < elem.x + VAR_WIDTH && p.mouseY > elem.y && p.mouseY < elem.y + VAR_HEIGHT) {
+          elem.font = 15;
+          elem.hovering = true;
+          elem.draw();
 
-    VARIABLES.forEach(elem => {
-
-      let w;
-      if (p.mouseX > elem.x && p.mouseX < elem.x + VAR_WIDTH && p.mouseY > elem.y && p.mouseY < elem.y + VAR_HEIGHT) {
-        // Each variable extends a custom amount depending on string length
-        if (elem.value.length < 4) {
-          w = VAR_WIDTH;
         } else {
-          w = VAR_WIDTH + (elem.value.length - 6) * 8.5;
+          elem.hovering = false;
         }
-
-        elem.font = 15;
-        elem.width = w;
-        elem.hovering = true;
-
-        elem.draw();
-
-      } else {
-        elem.width = VAR_WIDTH;
-        elem.hovering = false;
-      }
-    });
+      });
+    }
   }
 
   p.windowResized = () => {


### PR DESCRIPTION
\#159

# Description
Fixed two bugs - one preventing variables from resizing at all, and an edge case where variables were resizing whey they shouldn't.

# Change Log
Describe all changes made 
-`/visualizer/sketch/components/variable.js` : Move actual resizing code in here, refactor some things.
-`visualizer/sketch/sketch.js`: Move closing brace to actually include variable resizing functionality in the canvas draw function.

# Manual Test Steps
Create a variable and ensure that it resizes correctly regardless of the length of its value. It should only resize if the length of the string is greater than six.

