### PR TITLE
Simple comparators now work

### DIFF
--- a/src/interpreter/executor/enums.js
+++ b/src/interpreter/executor/enums.js
@@ -21,4 +21,6 @@ export const typeEnum = {
 export const operationsEnum = {
   ADDITION: '+',
   SUBTRACTION: '-',
+  LESS_THAN: '<',
+  GREATER_THAN: '>',
 };

--- a/src/interpreter/executor/interpret.js
+++ b/src/interpreter/executor/interpret.js
@@ -2,7 +2,7 @@ import { Console, Expression, Syntax, Unsupported, Variable } from './classes';
 import { stateEnum, operationsEnum } from './enums';
 import { increaseScope, decreaseScope, getClosestValue, insertVar} from './state';
 import { isNotCovered, isVariableName } from './util';
-import { addition, subtraction } from './operations';
+import { addition, subtraction, lessThan, greaterThan } from './operations';
 
 // Output of expressions for visualiser
 let output = [];
@@ -312,6 +312,16 @@ function arithmetic(buffer, inputLine, currentState) {
     right = inputLine.substring(inputLine.indexOf('-') + 1);
     right = getSubExpressionValue(getSubExpression(right));
     buffer = subtraction(left, right);
+    break;
+  case operationsEnum.LESS_THAN:
+    right = inputLine.substring(inputLine.indexOf('<') + 1);
+    right = getSubExpressionValue(getSubExpression(right));
+    buffer = lessThan(left, right);
+    break;
+  case operationsEnum.GREATER_THAN:
+    right = inputLine.substring(inputLine.indexOf('>') + 1);
+    right = getSubExpressionValue(getSubExpression(right));
+    buffer = greaterThan(left, right);
     break;
   default:
     newState = currentState;

--- a/src/interpreter/executor/operations.js
+++ b/src/interpreter/executor/operations.js
@@ -38,3 +38,42 @@ export function subtraction(left, right) {
   }
   return String(leftVal - rightVal);
 }
+
+export function lessThan(left, right) {
+  return abstractRelationalComparison(left, right, '<');
+}
+
+export function greaterThan(left, right) {
+  return abstractRelationalComparison(left, right, '>');
+}
+
+function abstractRelationalComparison(left, right, comparator) {
+  let leftVal = getValueIfVariable(left);
+  let rightVal = getValueIfVariable(right);
+
+  let leftType = deriveType(left);
+  let rightType = deriveType(right);
+
+  let lessThan = comparator === '<';
+
+  if (leftType === typeEnum.STRING && rightType === typeEnum.STRING) {
+    if (lessThan) {
+      return String(leftVal < rightVal);
+    } else {
+      return String(leftVal > rightVal);
+    }
+  }
+
+  leftVal = convertToNum(leftVal, leftType);
+  rightVal = convertToNum(rightVal, rightType);
+
+  if (isNaN(leftVal) || isNaN(rightVal)) {
+    return 'undefined';
+  }
+
+  if (lessThan) {
+    return String(leftVal < rightVal);
+  } else {
+    return String(leftVal > rightVal);
+  }
+}

--- a/src/interpreter/executor/util.js
+++ b/src/interpreter/executor/util.js
@@ -90,10 +90,6 @@ export function isNotCovered(buffer) {
     isNotCovered = true;
   } else if (buffer.includes('|')) {
     isNotCovered = true;
-  } else if (buffer.includes('<')) {
-    isNotCovered = true;
-  } else if (buffer.includes('>')) {
-    isNotCovered = true;
   } else if (buffer.includes('\\')) {
     isNotCovered = true;
   } else if (buffer.includes('null')) {


### PR DESCRIPTION
#177 
#176 

# Description

Adding support for less than and greater than first since they are only a single character.

# Change Log

-`enums.js` : Added more operators into our enum
-`interpret.js`: Added to our operator switch statement
-`util.js`: Removed previous unsupported conditionals
-`operations.js`: Following Ecma guidelines created functions to deal with relations

# Manual Test Steps
Manually test simple conditionals.  If you chain it will probably not work since our recursion is still messed up.
![yay](https://user-images.githubusercontent.com/8812688/32976219-ebadea28-cbdf-11e7-9ae1-03360cbd9317.png)

